### PR TITLE
Fix typos, 'silent' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Default: `hex`
 
 Select the color format between: `hex`, `rgb`, `rgba`.
 
+##### `silent`
+
+Type: `bool`
+
+Default: `false`
+
+Disable output info.
+
 ## Contributing
 
 If you want to improve the plugin, [send a pull request](https://github.com/ismamz/postcss-get-color/pull/new/master) ;-)

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Source: [Android Developers - Extract Color Profiles](https://developer.android.
 | `color: get-color("../img/girl.png", Vibrant);` | `color: #e8ba3c;` |
 
 
---- 
+---
 
 
 ### CSS Input
 
 ```css
 .foo {
-    background-color: get-color("path/to/image.jpg", LightVibrant) url("path/to/image.jpg) no-repeat;
+    background-color: get-color("path/to/image.jpg", LightVibrant) url("path/to/image.jpg") no-repeat;
 }
 
 .bar {
@@ -61,7 +61,7 @@ get-color(<image-path>, [<color-name>, <text-color>])
 
 **image-path** `string`: path to image relative to the CSS file (with quotes).
 
-**color-name** `string`: name (case sensitive) from the palette ([see available names](#vibrant-palette)). <br> _Default:_ first available color in the palette. 
+**color-name** `string`: name (case sensitive) from the palette ([see available names](#vibrant-palette)). <br> _Default:_ first available color in the palette.
 
 **text-color** `[title|body]`: get the compatible foreground color.
 

--- a/index.js
+++ b/index.js
@@ -197,7 +197,10 @@ module.exports = postcss.plugin('postcss-get-color', function (opts) {
 
         return Promise.all(promises).then(
             function (response) {
+              var silent = opts.silent;
+              if(!silent) {
                 console.log('\n\npostcss-get-color processed ' + response.length + ' images\n');
+              }
             },
             function (err) {
                 throw err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-get-color",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "PostCSS plugin to get the prominent colors from an image",
   "keywords": [
     "postcss",


### PR DESCRIPTION
A little bit update for readme (quotas in example code)
'silent' option for disabling output messages